### PR TITLE
Connector cannot be singleton

### DIFF
--- a/src/MailQ/Connector.php
+++ b/src/MailQ/Connector.php
@@ -17,7 +17,7 @@ class Connector
 
 	private $connectionTimeout = 300;
 
-	private static $instance;
+	private static $instances = [];
 
 	/**
 	 * Connector constructor.
@@ -43,10 +43,11 @@ class Connector
 	 */
 	public static function getInstance($baseUrl, $apiKey, $connectionTimeout = 300, $timeout = 0)
 	{
-		if (!isset(self::$instance)) {
-			self::$instance = new Connector($baseUrl, $apiKey,$connectionTimeout,$timeout);
-		}
-		return self::$instance;
+	    $instanceId = $baseUrl . '|' . $apiKey . '|' . $connectionTimeout . '|' . $timeout;
+	    if (!isset(self::$instances[$instanceId])) {
+	        self::$instances[$instanceId] = new Connector($baseUrl, $apiKey,$connectionTimeout,$timeout);
+        }
+		return self::$instances[$instanceId];
 	}
 
 	/**


### PR DESCRIPTION
When using MailQFactory (should be preffered), there is no ability to use more API keys per code run, because of Connector singleton.

This commit enables to cache Connectors, but better solution would probably be remove of $instances at all (getInstance would be then only __construct alias)